### PR TITLE
Print stacktrace

### DIFF
--- a/jsonlog
+++ b/jsonlog
@@ -101,6 +101,8 @@ for line in sys.stdin:
         level = data['level']
         message = data['message']
         print("[{}] {} [{}] {}".format(colorize_timestamp(timestamp), colorize_level(level), logger_name, colorize_message(message)))
+        if data['stackTrace']:
+            print(data['stackTrace'])
     except:
         print(line)
 print("-~-")


### PR DESCRIPTION
This is quick and dirty hack to print the stacktrace. Feel free to reimplement it nicely. Don't know if it doesn't break when there is no stacktrace.